### PR TITLE
Feat/47 db user functions

### DIFF
--- a/apps/backend/src/db/dbTypes/fastify.d.ts
+++ b/apps/backend/src/db/dbTypes/fastify.d.ts
@@ -1,0 +1,9 @@
+import { FastifyInstance } from 'fastify'
+import { DbType } from './types'
+
+/* Still trying to understand if this is needed */
+declare module 'fastify' {
+	interface FastifyInstance {
+		db: DbType 
+	}
+}

--- a/apps/backend/src/db/dbTypes/types.ts
+++ b/apps/backend/src/db/dbTypes/types.ts
@@ -1,0 +1,5 @@
+import { drizzle } from 'drizzle-orm/libsql'
+import * as schema from '../src/dbSchema/schema'
+
+/* Create the database type to be used */
+export type DbType = ReturnType<typeof drizzle<typeof schema>>;

--- a/apps/backend/src/db/drizzle.config.ts
+++ b/apps/backend/src/db/drizzle.config.ts
@@ -9,7 +9,7 @@ config({ path: path.resolve(__dirname, '../../../../.env') });
 
 export default defineConfig({
 	out: 'src/db/drizzle',
-	schema: path.resolve(__dirname, 'src/db_schema/schema.ts'),
+	schema: path.resolve(__dirname, 'src/dbSchema/schema.ts'),
 	dialect: 'sqlite',
 	dbCredentials: {
 		url: path.resolve(__dirname, process.env.DB_FILE_NAME!) // This will create the database file in the apps/backend/src/db folder, easily modifiable

--- a/apps/backend/src/db/drizzle/0003_cuddly_forge.sql
+++ b/apps/backend/src/db/drizzle/0003_cuddly_forge.sql
@@ -1,0 +1,35 @@
+DROP INDEX `unique_match_idx`;--> statement-breakpoint
+CREATE UNIQUE INDEX `unique_match_idx` ON `match_history_table` (`createdAt`,`victor`);--> statement-breakpoint
+ALTER TABLE `match_history_table` DROP COLUMN `mode`;--> statement-breakpoint
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_single_match_players_table` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`matchId` integer NOT NULL,
+	`player` integer NOT NULL,
+	`placement` integer DEFAULT 0 NOT NULL,
+	FOREIGN KEY (`matchId`) REFERENCES `match_history_table`(`id`) ON UPDATE no action ON DELETE no action,
+	FOREIGN KEY (`player`) REFERENCES `users_table`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+INSERT INTO `__new_single_match_players_table`("id", "matchId", "player", "placement") SELECT "id", "matchId", "player", "placement" FROM `single_match_players_table`;--> statement-breakpoint
+DROP TABLE `single_match_players_table`;--> statement-breakpoint
+ALTER TABLE `__new_single_match_players_table` RENAME TO `single_match_players_table`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE UNIQUE INDEX `unique_participation_idx` ON `single_match_players_table` (`player`,`matchId`);--> statement-breakpoint
+CREATE TABLE `__new_users_table` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`alias` text NOT NULL,
+	`password` text NOT NULL,
+	`name` text,
+	`email` text,
+	`avatarPath` text DEFAULT 'avatar_default',
+	`backgroundPath` text DEFAULT 'background_default',
+	`wins` integer DEFAULT 0 NOT NULL,
+	`losses` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+INSERT INTO `__new_users_table`("id", "alias", "password", "name", "email", "avatarPath", "backgroundPath", "wins", "losses") SELECT "id", "alias", "password", "name", "email", "avatarPath", "backgroundPath", "wins", "losses" FROM `users_table`;--> statement-breakpoint
+DROP TABLE `users_table`;--> statement-breakpoint
+ALTER TABLE `__new_users_table` RENAME TO `users_table`;--> statement-breakpoint
+CREATE UNIQUE INDEX `users_table_alias_unique` ON `users_table` (`alias`);--> statement-breakpoint
+CREATE UNIQUE INDEX `users_table_email_unique` ON `users_table` (`email`);

--- a/apps/backend/src/db/drizzle/0004_classy_post.sql
+++ b/apps/backend/src/db/drizzle/0004_classy_post.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `users_table` DROP COLUMN `wins`;--> statement-breakpoint
+ALTER TABLE `users_table` DROP COLUMN `losses`;

--- a/apps/backend/src/db/drizzle/meta/0003_snapshot.json
+++ b/apps/backend/src/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,311 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5db401e4-520d-49f0-a9bc-35b7d8d602e0",
+  "prevId": "7055773e-8e8d-4dd5-8d3c-117168950917",
+  "tables": {
+    "friendships_table": {
+      "name": "friendships_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "friendId": {
+          "name": "friendId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_friendship_idx": {
+          "name": "unique_friendship_idx",
+          "columns": [
+            "userId",
+            "friendId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "friendships_table_userId_users_table_id_fk": {
+          "name": "friendships_table_userId_users_table_id_fk",
+          "tableFrom": "friendships_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "friendships_table_friendId_users_table_id_fk": {
+          "name": "friendships_table_friendId_users_table_id_fk",
+          "tableFrom": "friendships_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "friendId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "check_befriend_self": {
+          "name": "check_befriend_self",
+          "value": "\"friendships_table\".\"userId\" != \"friendships_table\".\"friendId\""
+        }
+      }
+    },
+    "match_history_table": {
+      "name": "match_history_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "victor": {
+          "name": "victor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_match_idx": {
+          "name": "unique_match_idx",
+          "columns": [
+            "createdAt",
+            "victor"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "match_history_table_victor_users_table_id_fk": {
+          "name": "match_history_table_victor_users_table_id_fk",
+          "tableFrom": "match_history_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "victor"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "single_match_players_table": {
+      "name": "single_match_players_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "matchId": {
+          "name": "matchId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_participation_idx": {
+          "name": "unique_participation_idx",
+          "columns": [
+            "player",
+            "matchId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "single_match_players_table_matchId_match_history_table_id_fk": {
+          "name": "single_match_players_table_matchId_match_history_table_id_fk",
+          "tableFrom": "single_match_players_table",
+          "tableTo": "match_history_table",
+          "columnsFrom": [
+            "matchId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "single_match_players_table_player_users_table_id_fk": {
+          "name": "single_match_players_table_player_users_table_id_fk",
+          "tableFrom": "single_match_players_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "player"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarPath": {
+          "name": "avatarPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'avatar_default'"
+        },
+        "backgroundPath": {
+          "name": "backgroundPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'background_default'"
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "users_table_alias_unique": {
+          "name": "users_table_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        },
+        "users_table_email_unique": {
+          "name": "users_table_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/backend/src/db/drizzle/meta/0004_snapshot.json
+++ b/apps/backend/src/db/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,295 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "eb6055e5-b856-41df-b60b-739c9112e92e",
+  "prevId": "5db401e4-520d-49f0-a9bc-35b7d8d602e0",
+  "tables": {
+    "friendships_table": {
+      "name": "friendships_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "friendId": {
+          "name": "friendId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_friendship_idx": {
+          "name": "unique_friendship_idx",
+          "columns": [
+            "userId",
+            "friendId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "friendships_table_userId_users_table_id_fk": {
+          "name": "friendships_table_userId_users_table_id_fk",
+          "tableFrom": "friendships_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "userId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "friendships_table_friendId_users_table_id_fk": {
+          "name": "friendships_table_friendId_users_table_id_fk",
+          "tableFrom": "friendships_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "friendId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "check_befriend_self": {
+          "name": "check_befriend_self",
+          "value": "\"friendships_table\".\"userId\" != \"friendships_table\".\"friendId\""
+        }
+      }
+    },
+    "match_history_table": {
+      "name": "match_history_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "victor": {
+          "name": "victor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "createdAt": {
+          "name": "createdAt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "unique_match_idx": {
+          "name": "unique_match_idx",
+          "columns": [
+            "createdAt",
+            "victor"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "match_history_table_victor_users_table_id_fk": {
+          "name": "match_history_table_victor_users_table_id_fk",
+          "tableFrom": "match_history_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "victor"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "single_match_players_table": {
+      "name": "single_match_players_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "matchId": {
+          "name": "matchId",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "player": {
+          "name": "player",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "placement": {
+          "name": "placement",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "unique_participation_idx": {
+          "name": "unique_participation_idx",
+          "columns": [
+            "player",
+            "matchId"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "single_match_players_table_matchId_match_history_table_id_fk": {
+          "name": "single_match_players_table_matchId_match_history_table_id_fk",
+          "tableFrom": "single_match_players_table",
+          "tableTo": "match_history_table",
+          "columnsFrom": [
+            "matchId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "single_match_players_table_player_users_table_id_fk": {
+          "name": "single_match_players_table_player_users_table_id_fk",
+          "tableFrom": "single_match_players_table",
+          "tableTo": "users_table",
+          "columnsFrom": [
+            "player"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users_table": {
+      "name": "users_table",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "alias": {
+          "name": "alias",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatarPath": {
+          "name": "avatarPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'avatar_default'"
+        },
+        "backgroundPath": {
+          "name": "backgroundPath",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'background_default'"
+        }
+      },
+      "indexes": {
+        "users_table_alias_unique": {
+          "name": "users_table_alias_unique",
+          "columns": [
+            "alias"
+          ],
+          "isUnique": true
+        },
+        "users_table_email_unique": {
+          "name": "users_table_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/apps/backend/src/db/drizzle/meta/_journal.json
+++ b/apps/backend/src/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1755109606230,
       "tag": "0003_cuddly_forge",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1755114512388,
+      "tag": "0004_classy_post",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/drizzle/meta/_journal.json
+++ b/apps/backend/src/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1754429674493,
       "tag": "0002_lethal_randall_flagg",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1755109606230,
+      "tag": "0003_cuddly_forge",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/src/dbClientInit.ts
+++ b/apps/backend/src/db/src/dbClientInit.ts
@@ -4,7 +4,7 @@ import { createClient } from '@libsql/client';
 import { drizzle } from 'drizzle-orm/libsql';
 
 
-config({ path: path.resolve(__dirname, '../../../../../.env') }); // This works only if the .env used is in the root of the project, process.cwd() can also be used with different path resolution. It depends on the project structure and where the .env file will be stored or if there will be multiple.
+config({ path: path.resolve(process.cwd(), '.env') }); // This works only if the .env used is in the root of the backend.
 
 const dbFilePath = path.resolve(__dirname, '../', process.env.DB_FILE_NAME!);
 

--- a/apps/backend/src/db/src/dbClientInit.ts
+++ b/apps/backend/src/db/src/dbClientInit.ts
@@ -1,0 +1,15 @@
+import { config } from 'dotenv';
+import path from 'path';
+import { createClient } from '@libsql/client';
+import { drizzle } from 'drizzle-orm/libsql';
+
+
+config({ path: path.resolve(__dirname, '../../../../../.env') }); // This works only if the .env used is in the root of the project, process.cwd() can also be used with different path resolution. It depends on the project structure and where the .env file will be stored or if there will be multiple.
+
+const dbFilePath = path.resolve(__dirname, '../', process.env.DB_FILE_NAME!);
+
+const client = createClient({
+  url: `file:${dbFilePath}`
+});
+
+export const db = drizzle(client);

--- a/apps/backend/src/db/src/dbFunctions.ts
+++ b/apps/backend/src/db/src/dbFunctions.ts
@@ -1,9 +1,18 @@
 import { usersTable } from './dbSchema/schema';
 import { db } from './dbClientInit'
+import { eq } from 'drizzle-orm'
 
-/* Create and return a user, [createdUser] is destructuring the array returned from returning(),
-and capturing the first element. It returns because it might be needed to use info from the new entry */
 type NewUser = typeof usersTable.$inferInsert;
+type ExistingUser = typeof usersTable.$inferSelect;
+
+/**
+ * Create and return a user, [createdUser] is destructuring the array returned from returning(),
+ * and capturing the first element. It returns because it might be needed to use info from the new entry
+ * @param newAlias alias of the new user 
+ * @param newEmail email of the new user
+ * @param newPassword password of the new user
+ * @returns The user data or throws an error
+ */
 export async function createUser(newAlias: string, newEmail: string, newPassword: string): Promise<NewUser> {
   try {
     const [createdUser] = await db.insert(usersTable).values({
@@ -20,6 +29,48 @@ export async function createUser(newAlias: string, newEmail: string, newPassword
       console.log('Unknown error');
       console.log(error);
     }
+    throw error;
+  }
+}
+
+/**
+ * Search for an existing user with its alias
+ * @param alias alias of existing user
+ * @returns The user data or null or throws an error
+ */
+export async function findUserByAlias(alias: string): Promise<ExistingUser | null> {
+  if (!alias) {
+    throw new Error('findUserByAlias error: alias must be provided');
+  }
+
+  try {
+    // Here we can decide on the selected columns to return
+    const [foundUser] = await db.select().from(usersTable).where(eq(usersTable.alias, alias));
+    return foundUser ?? null;
+  } catch (error) {
+    console.log('Unknown error searching for user');
+    console.log(error);
+    throw error;
+  }
+}
+
+/**
+ * Search for an existing user with its alias
+ * @param email email of existing user
+ * @returns The user data or null or throws an error
+ */
+export async function findUserByEmail(email: string): Promise<ExistingUser | null> {
+  if (!email) {
+    throw new Error('findUserByAlias error: email must be provided');
+  }
+
+  try {
+    // Here we can decide on the selected columns to return
+    const [foundUser] = await db.select().from(usersTable).where(eq(usersTable.email, email));
+    return foundUser ?? null;
+  } catch (error) {
+    console.log('Unknown error searching for user');
+    console.log(error);
     throw error;
   }
 }

--- a/apps/backend/src/db/src/dbFunctions.ts
+++ b/apps/backend/src/db/src/dbFunctions.ts
@@ -1,0 +1,25 @@
+import { usersTable } from './dbSchema/schema';
+import { db } from './dbClientInit'
+
+/* Create and return a user, [createdUser] is destructuring the array returned from returning(),
+and capturing the first element. It returns because it might be needed to use info from the new entry */
+type NewUser = typeof usersTable.$inferInsert;
+export async function createUser(newAlias: string, newEmail: string, newPassword: string): Promise<NewUser> {
+  try {
+    const [createdUser] = await db.insert(usersTable).values({
+      alias: newAlias,
+      email: newEmail,
+      password: newPassword,
+    }).returning();
+    return createdUser;
+  } catch (error) {
+    if (error instanceof Error && error.message.includes('Failed query: insert into "users_table"')) {
+      console.log('! Failed to store user !');
+      console.log(error.message);
+    } else {
+      console.log('Unknown error');
+      console.log(error);
+    }
+    throw error;
+  }
+}

--- a/apps/backend/src/db/src/dbSchema/schema.ts
+++ b/apps/backend/src/db/src/dbSchema/schema.ts
@@ -9,14 +9,14 @@ export const usersTable = sqliteTable(
 		alias: text().notNull().unique(),
     password: text().notNull(),
 		name: text(),
-		email: text().notNull().unique(), // Do we want email to be a mandatory field?
+		email: text().unique(), // Do we want email to be a mandatory field?
     avatarPath: text().default('avatar_default'),
     backgroundPath: text().default('background_default'),
-    lastLoginTime: int({ mode: 'timestamp' }),
-    lastActivityTime: int({ mode: 'timestamp' }), // we can use this to display last seen status, I understand that online status will come from memory
-    totalMatches: int().notNull().default(0),
     wins: int().notNull().default(0),
     losses: int().notNull().default(0),
+    // lastLoginTime: int({ mode: 'timestamp' }),
+    // lastActivityTime: int({ mode: 'timestamp' }), // we can use this to display last seen status, I understand that online status will come from memory
+    // totalMatches: int().notNull().default(0),
 });
 
 /* Table for all the friendships -> So that we don't have duplicates,
@@ -42,15 +42,15 @@ export const friendshipsTable = sqliteTable(
 export const matchHistoryTable = sqliteTable(
   "match_history_table", {
 	id: int().primaryKey({ autoIncrement: true }),
-	mode: text().notNull(),
 	victor: int().notNull().references((): AnySQLiteColumn => usersTable.id),
 	createdAt: int({ mode: 'timestamp' }).notNull(),
+	// mode: int().notNull(), // Number of participants
 },
 (table) => [
 	uniqueIndex("unique_match_idx").on(
 		table.createdAt,
-		table.mode,
 		table.victor,
+		// table.mode,
 		)
 ]);
 
@@ -59,10 +59,10 @@ by also including the data from the referenced match in the matchHistoryTable */
 export const singleMatchParticipantsTable = sqliteTable(
   "single_match_players_table", {
 	id: int().primaryKey({ autoIncrement: true }),
-	player: int().notNull().references((): AnySQLiteColumn => usersTable.id),
-	score: int().notNull().default(0),
-	placement: int().notNull().default(-1),
 	matchId: int().notNull().references((): AnySQLiteColumn => matchHistoryTable.id),
+	player: int().notNull().references((): AnySQLiteColumn => usersTable.id),
+	placement: int().notNull().default(0), // This will be the the position that players finish at, only position 1 will be considered a victory 
+	// score: int().notNull().default(0),
 },
 (table) => [
 	uniqueIndex("unique_participation_idx").on(

--- a/apps/backend/src/db/src/dbSchema/schema.ts
+++ b/apps/backend/src/db/src/dbSchema/schema.ts
@@ -12,11 +12,8 @@ export const usersTable = sqliteTable(
 		email: text().unique(), // Do we want email to be a mandatory field?
     avatarPath: text().default('avatar_default'),
     backgroundPath: text().default('background_default'),
-    wins: int().notNull().default(0),
-    losses: int().notNull().default(0),
     // lastLoginTime: int({ mode: 'timestamp' }),
     // lastActivityTime: int({ mode: 'timestamp' }), // we can use this to display last seen status, I understand that online status will come from memory
-    // totalMatches: int().notNull().default(0),
 });
 
 /* Table for all the friendships -> So that we don't have duplicates,
@@ -44,13 +41,11 @@ export const matchHistoryTable = sqliteTable(
 	id: int().primaryKey({ autoIncrement: true }),
 	victor: int().notNull().references((): AnySQLiteColumn => usersTable.id),
 	createdAt: int({ mode: 'timestamp' }).notNull(),
-	// mode: int().notNull(), // Number of participants
 },
 (table) => [
 	uniqueIndex("unique_match_idx").on(
 		table.createdAt,
 		table.victor,
-		// table.mode,
 		)
 ]);
 
@@ -62,7 +57,6 @@ export const singleMatchParticipantsTable = sqliteTable(
 	matchId: int().notNull().references((): AnySQLiteColumn => matchHistoryTable.id),
 	player: int().notNull().references((): AnySQLiteColumn => usersTable.id),
 	placement: int().notNull().default(0), // This will be the the position that players finish at, only position 1 will be considered a victory 
-	// score: int().notNull().default(0),
 },
 (table) => [
 	uniqueIndex("unique_participation_idx").on(

--- a/apps/backend/src/db/src/dbSchema/schema.ts
+++ b/apps/backend/src/db/src/dbSchema/schema.ts
@@ -9,7 +9,7 @@ export const usersTable = sqliteTable(
 		alias: text().notNull().unique(),
     password: text().notNull(),
 		name: text(),
-		email: text().notNull().unique(),
+		email: text().notNull().unique(), // Do we want email to be a mandatory field?
     avatarPath: text().default('avatar_default'),
     backgroundPath: text().default('background_default'),
     lastLoginTime: int({ mode: 'timestamp' }),

--- a/apps/backend/src/db/src/db_test.ts
+++ b/apps/backend/src/db/src/db_test.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 import { friendshipsTable, matchHistoryTable, singleMatchParticipantsTable, usersTable } from './dbSchema/schema';
 import { reset } from 'drizzle-seed';
 import { db } from './dbClientInit';
-import { createUser } from './dbFunctions';
+import { createUser, findUserByAlias, findUserByEmail } from './dbFunctions';
 
 console.log(__dirname);
 
@@ -49,6 +49,22 @@ async function main() {
 
   const users_3 = await db.select().from(usersTable);
   console.log('Getting all users from the database: ', users_3);
+
+  /* Test findUserByAlias */
+  console.log('-------findUserByAlias---------');
+  const testUserAlias =  `testUser${Date.now()}`;
+  const testUserEmail = `exampleEmail${Date.now()}`;
+  const testUserPassword = `pass${Date.now()}`;
+  await createUser(testUserAlias, testUserEmail, testUserPassword);
+  let foundUser = await findUserByAlias(testUserAlias);
+  console.log(foundUser);
+  console.log('-------------------------------');
+  console.log('-------findUserByEmail---------');
+  foundUser = await findUserByEmail(testUserEmail);
+  console.log(foundUser);
+  console.log('-------------------------------');
+
+
 
 
   // Capture all user ids in an array

--- a/apps/backend/src/db/types/fastify.d.ts
+++ b/apps/backend/src/db/types/fastify.d.ts
@@ -1,9 +1,0 @@
-import { FastifyInstance } from 'fastify'
-import { drizzle } from 'drizzle-orm/libsql'
-import * as schema from '../src/db/schema'
-
-declare module 'fastify' {
-	interface FastifyInstance {
-		db: ReturnType<typeof drizzle<typeof schema>> 
-	}
-}


### PR DESCRIPTION
- Implemented function to create a user and to find a user by alias or email. These functions return the user data as an object that we can access its elements with the '.' operator. The implementations can be adjusted for specific columns in the future.

- Changed the schema a little bit, removed some columns for now. To work with the new schema we need to do db:migrate so the changes pass to our database. If you don't have an established local database, db:generate and then db:migrate is the way to go. If you encounter issues with this let me know.
