### PR TITLE
fix: logger in bakend, by disabling request logging,

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -30,7 +30,8 @@
     "drizzle-seed": "^0.3.1",
     "fastify": "^5.4.0",
     "jsonwebtoken": "^9.0.2",
-    "nodemon": "^3.1.10"
+    "nodemon": "^3.1.10",
+    "pino": "^9.10.0"
   },
   "devDependencies": {
     "@fastify/cors": "^11.1.0",

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -4,9 +4,14 @@ import { appRouter } from '@repo/trpc';
 import { createTRPCContext } from './trpc/context';
 import websocket from '@fastify/websocket';
 import { setupGoogleAuthRoutes } from './auth/google';
+import pino from 'pino';
 // Create a Fastify instance
 const fastifyInstance = Fastify({
-  logger: true,
+  disableRequestLogging: true,
+  logger: {
+    level: 'info',
+    timestamp: pino.stdTimeFunctions.isoTime,
+  },
 });
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       nodemon:
         specifier: ^3.1.10
         version: 3.1.10
+      pino:
+        specifier: ^9.10.0
+        version: 9.10.0
     devDependencies:
       '@fastify/cors':
         specifier: ^11.1.0
@@ -1845,8 +1848,8 @@ packages:
   pino-std-serializers@7.0.0:
     resolution: {integrity: sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==}
 
-  pino@9.7.0:
-    resolution: {integrity: sha512-vnMCM6xZTb1WDmLvtG2lE/2p+t9hDEIvTWJsu6FejkE62vB7gDhvzrpFR4Cw2to+9JNQxVnkAKVPA1KPB98vWg==}
+  pino@9.10.0:
+    resolution: {integrity: sha512-VOFxoNnxICtxaN8S3E73pR66c5MTFC+rwRcNRyHV/bV/c90dXvJqMfjkeRFsGBDXmlUN3LccJQPqGIufnaJePA==}
     hasBin: true
 
   postcss-selector-parser@6.0.10:
@@ -3308,7 +3311,7 @@ snapshots:
       fast-json-stringify: 6.0.1
       find-my-way: 9.3.0
       light-my-request: 6.6.0
-      pino: 9.7.0
+      pino: 9.10.0
       process-warning: 5.0.0
       rfdc: 1.4.1
       secure-json-parse: 4.0.0
@@ -3676,7 +3679,7 @@ snapshots:
 
   pino-std-serializers@7.0.0: {}
 
-  pino@9.7.0:
+  pino@9.10.0:
     dependencies:
       atomic-sleep: 1.0.0
       fast-redact: 3.5.0


### PR DESCRIPTION
Disable Fastify's automatic request logging to allow backend console.log output in the terminal
